### PR TITLE
Add `up` subcommand to `docker compose` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,24 @@ To run the tool to perform these steps:
 
 2. Build the necessary Java code.
 	- commands: ```cd Truck-Factor/gittruckfactor; mvn package```
-  - docker: ```cd Truck-Factor/gittruckfactor; docker compose jar```
+  - docker: ```cd Truck-Factor/gittruckfactor; docker compose up jar```
 
 2. Execute the scripts to extract information from the git repository to be analyzed:
     1. Extract commit and file information. 
         - command: ```./scripts/commit_log_script.sh  <git_repository_path>```
         - example: ```./scripts/commit_log_script.sh  git/Truck-Factor```
-        - docker: ```docker compose commit_info```
+        - docker: ```docker compose up commit_info```
 	
 	
     2. Extract files to be discard using Linguist library (Optional)
         - command: ```./scripts/linguist_script.sh <git_repository_path>```
         - example: ```./scripts/linguist_script.sh git/Truck-Factor```
-        - docker: ```docker compose linguist```
+        - docker: ```docker compose up linguist```
 	
 3. Execute the gittruckfactor tool.
     - command: ```java –jar gittruckfactor-1.0.jar <git_repository_path> <git_repository_fullname>```
     - example: ```java –jar gittruckfactor-1.0.jar git/Truck-Factor aserg-ufmg/Truck-Factor```
-    - docker: ```docker compose execute```
+    - docker: ```docker compose up execute```
 
 ## Optional Settings
 


### PR DESCRIPTION
The `docker compose` instructions in the README don't work as currently written, the `up` subcommand needs to be added.

## Before

<img width="1728" alt="Screenshot 2024-11-12 at 10 35 28" src="https://github.com/user-attachments/assets/fb666ec7-e249-4256-8264-d061da728b81">

## After

<img width="1728" alt="Screenshot 2024-11-12 at 10 49 58" src="https://github.com/user-attachments/assets/d51e00ff-6933-4285-a165-229f5afbf5b4">
